### PR TITLE
8-core-runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04-64core, macos-latest, windows-2022-32core]
+        os: [ubuntu-20.04-64core, macos-latest-xlarge, windows-2022-32core]
         include:
           - os-name: linux
             os: ubuntu-20.04-64core

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,14 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04-64core]
+        os: [ubuntu-20.04-64core, macos-latest, windows-2022-32core]
         include:
           - os-name: linux
             os: ubuntu-20.04-64core
+          - os-name: windows
+            os: windows-2022-32core
+          - os-name: macOS
+            os: macos-latest-xlarge
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.os-name }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-22.04-8core, macos-latest-large, windows-2022-8core]
+        os: [ubuntu-22.04-8core, macos-latest-xlarge, windows-2022-8core]
         include:
           - os-name: linux
             os: ubuntu-20.04-8core
           - os-name: windows
             os: windows-2022-8core
           - os-name: macOS
-            os: macos-latest-large
+            os: macos-latest-xlarge
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.os-name }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-20.04-64core, macos-latest, windows-2022]
         include:
           - os-name: linux
-            os: ubuntu-20.04
+            os: ubuntu-20.04-64core
           - os-name: macOS
             os: macos-latest
           - os-name: windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,28 +12,28 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04-32core, macos-latest-xlarge, windows-2022-32core]
+        os: [ubuntu-22.04-8core, macos-latest-large, windows-2022-8core]
         include:
           - os-name: linux
-            os: ubuntu-20.04-32core
+            os: ubuntu-22.04-8core
           - os-name: windows
-            os: windows-2022-32core
+            os: windows-2022-8core
           - os-name: macOS
-            os: macos-latest-xlarge
+            os: macos-latest-large
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.os-name }})
     steps:
       - uses: actions/checkout@v3
-      # - name: Cache
-      #   id: cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/bazel-disk-cache
-      #     key: bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
-      #     # Intentionally not reusing an older cache entry using a key prefix, bazel frequently
-      #     # ends up with a larger cache at the end when starting with an available cache entry,
-      #     # resulting in a snowballing cache size and cache download/upload times.
+      - name: Cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: ~/bazel-disk-cache
+          key: bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
+          # Intentionally not reusing an older cache entry using a key prefix, bazel frequently
+          # ends up with a larger cache at the end when starting with an available cache entry,
+          # resulting in a snowballing cache size and cache download/upload times.
       - name: Setup Linux
         if: runner.os == 'Linux'
         # Install dependencies, including clang via through LLVM APT repository. Note that this

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,10 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04-64core, macos-latest, windows-2022]
+        os: [ubuntu-20.04-64core]
         include:
           - os-name: linux
             os: ubuntu-20.04-64core
-          - os-name: macOS
-            os: macos-latest
-          - os-name: windows
-            os: windows-2022
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.os-name }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-22.04-8core, macos-latest-large, windows-2022-8core]
         include:
           - os-name: linux
-            os: ubuntu-22.04-8core
+            os: ubuntu-20.04-8core
           - os-name: windows
             os: windows-2022-8core
           - os-name: macOS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-2022]
+        os: [ubuntu-20.04-64core, macos-latest, windows-2022]
         include:
           - os-name: linux
             os: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04-64core, macos-latest-xlarge, windows-2022-32core]
+        os: [ubuntu-20.04-32core, macos-latest-xlarge, windows-2022-32core]
         include:
           - os-name: linux
-            os: ubuntu-20.04-64core
+            os: ubuntu-20.04-32core
           - os-name: windows
             os: windows-2022-32core
           - os-name: macOS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,15 +25,15 @@ jobs:
     name: test (${{ matrix.os-name }})
     steps:
       - uses: actions/checkout@v3
-      - name: Cache
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: ~/bazel-disk-cache
-          key: bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
-          # Intentionally not reusing an older cache entry using a key prefix, bazel frequently
-          # ends up with a larger cache at the end when starting with an available cache entry,
-          # resulting in a snowballing cache size and cache download/upload times.
+      # - name: Cache
+      #   id: cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/bazel-disk-cache
+      #     key: bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
+      #     # Intentionally not reusing an older cache entry using a key prefix, bazel frequently
+      #     # ends up with a larger cache at the end when starting with an available cache entry,
+      #     # resulting in a snowballing cache size and cache download/upload times.
       - name: Setup Linux
         if: runner.os == 'Linux'
         # Install dependencies, including clang via through LLVM APT repository. Note that this


### PR DESCRIPTION
#### **We could have CI take 7 minutes total, instead of the _32 minutes_ it takes today**

### Linux — 8core
$0.032 / min * 6 = $0.19 per run ([example](https://github.com/partygoal/workerd/actions/runs/6437299418/job/17482204804))

### MacOS — xlarge
$0.16 / min * 7 = $1.12 per run

### Windows — 8core
$0.064 / min * 7 = $0.448 per run ([example](https://github.com/partygoal/workerd/actions/runs/6437299418/job/17482205052))

Then have ASAN builds run in CI?

### Linux — 64core

Before: 7:46 build, 41s test ([example](https://github.com/cloudflare/workerd/actions/runs/6424482461/job/17445209347?pr=1279))
After: 5:56 build, 22s test ([example](https://github.com/partygoal/workerd/actions/runs/6436618987/job/17480309802?pr=1))

### Windows — 32core

Before: 26:16 build, 2:16 test ([example](https://github.com/cloudflare/workerd/actions/runs/6424482461/job/17445209820?pr=1279))
After: 3:09 build, 40s test ([example](https://github.com/partygoal/workerd/actions/runs/6436798357/job/17480855553?pr=1))

### Mac — xlarge

Before: 11:37 build, 01:51 test ([example](https://github.com/cloudflare/workerd/actions/runs/6424482461/job/17445209615?pr=1279))
After: 01:52 build, 00:03 test ([example](https://github.com/partygoal/workerd/actions/runs/6437066560/job/17481582985?pr=1))